### PR TITLE
get path from Main.packages

### DIFF
--- a/Classes/Sleet.sc
+++ b/Classes/Sleet.sc
@@ -1,12 +1,12 @@
 Sleet {
-	var <quarkpath, <modules, <synthdefs, <list;
+	var <classpath, <modules, <synthdefs, <list;
 
 	*new { | numChannels=2|
 		^super.new.init( numChannels );
 	}
 
 	init { | numChannels |
-		quarkpath = Quark("Sleet").localPath;
+		classpath = Main.packages.asDict.at('Sleet');
 		modules = IdentityDictionary.new;
 		list=IdentityDictionary.new;
 
@@ -16,15 +16,15 @@ Sleet {
 	}
 
 	loadModulesToDict{|numChannels|
-		var folder = quarkpath +/+ "modules";
+		var folder = classpath +/+ "modules";
 
 		// Iterate over a folder of files containing sleet modules
-		PathName(folder).filesDo{|f| 
+		PathName(folder).filesDo{|f|
 			var ext = f.extension;
 			var name = f.fileNameWithoutExtension.asSymbol;
 
 			// Only normal SuperCollider files
-			if(ext == "scd", { 
+			if(ext == "scd", {
 				var contents;
 				"found module file: %".format(name).poststamped;
 


### PR DESCRIPTION
Now "Sleet" can be used as both a Quark and as a cloned or downloaded repo.
Main.packages scans everything. Quark.localPath will fail if someone uses the repo without installing it via Quarks.install

fixes #1